### PR TITLE
Fix uninitialized memory usage

### DIFF
--- a/c++/hal2psl.cpp
+++ b/c++/hal2psl.cpp
@@ -32,6 +32,9 @@ std::vector<PslBlock> hal::Hal2Psl::convert2psl(hal::AlignmentConstPtr alignment
     if (srcGenome->getNumSequences() > 0){
         _srcGenome = srcGenome;
         _tgtGenome = tgtGenome; 
+        _coalescenceLimit = NULL;
+        _traverseDupes = true;
+        _addExtraColumns = false;
         _missedSet.clear();
         _tgtSet.clear();
         _tgtSet.insert(tgtGenome);


### PR DESCRIPTION
Hi,

When running with valgrind I noticed that there was some uninitialized memory used. Maybe this is what's causing the weird results you're getting? It's totally possible that `_coalescenceLimit` being incorrect could cause some alignments to be missed, for example. Hopefully this fixes things!

What should `_addExtraColumns` be set to? I'm not really sure what it does.